### PR TITLE
fix: integrate .gitignore to refine file processing in `generate_over all_structure`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,8 +123,8 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
-.venv
+.env/
+.venv/
 env/
 venv/
 ENV/

--- a/ai_doc/file_handler.py
+++ b/ai_doc/file_handler.py
@@ -4,7 +4,7 @@ import git
 import os,json
 import ast
 from .config import CONFIG
-
+from .utils.gitignore_checker import GitignoreChecker
 
 # 这个类会在遍历变更后的文件的循环中，为每个变更后文件（也就是当前文件）创建一个实例
 class FileHandler:
@@ -176,13 +176,18 @@ class FileHandler:
 
             return file_objects
 
-    def generate_overall_structure(self):
+    def generate_overall_structure(self) -> dict:
+        """
+        Generate the overall structure of the repository.
+
+        Returns:
+            dict: A dictionary representing the structure of the repository.
+        """
         repo_structure = {}
-        for root, dirs, files in os.walk(self.repo_path):
-            for file in files:
-                if file.endswith('.py'):
-                    relative_file_path = os.path.relpath(os.path.join(root, file), self.repo_path)
-                    repo_structure[relative_file_path] = self.generate_file_structure(relative_file_path)
+        gitignore_checker = GitignoreChecker(directory=self.repo_path,
+                                            gitignore_path=os.path.join(self.repo_path, '.gitignore'))
+        for not_ignored_files in gitignore_checker.check_files_and_folders():
+            repo_structure[not_ignored_files] = self.generate_file_structure(not_ignored_files)
         return repo_structure
     
     # def convert_structure_to_json(self, repo_structure):

--- a/ai_doc/utils/gitignore_checker.py
+++ b/ai_doc/utils/gitignore_checker.py
@@ -1,0 +1,114 @@
+import fnmatch
+import os
+
+
+class GitignoreChecker:
+    def __init__(self, directory: str, gitignore_path: str):
+        """
+        Initialize the GitignoreChecker with a specific directory and the path to a .gitignore file.
+
+        Args:
+            directory (str): The directory to be checked.
+            gitignore_path (str): The path to the .gitignore file.
+        """
+        self.directory = directory
+        self.gitignore_path = gitignore_path
+        self.folder_patterns, self.file_patterns = self._load_gitignore_patterns()
+
+    def _load_gitignore_patterns(self) -> tuple:
+        """
+        Load and parse the .gitignore file, then split the patterns into folder and file patterns.
+
+        Returns:
+            tuple: A tuple containing two lists - one for folder patterns and one for file patterns.
+        """
+        with open(self.gitignore_path, 'r', encoding='utf-8') as file:
+            gitignore_content = file.read()
+
+        patterns = self._parse_gitignore(gitignore_content)
+        return self._split_gitignore_patterns(patterns)
+
+    @staticmethod
+    def _parse_gitignore(gitignore_content: str) -> list:
+        """
+        Parse the .gitignore content and return patterns as a list.
+
+        Args:
+            gitignore_content (str): The content of the .gitignore file.
+
+        Returns:
+            list: A list of patterns extracted from the .gitignore content.
+        """
+        patterns = []
+        for line in gitignore_content.splitlines():
+            line = line.strip()
+            if line and not line.startswith('#'):
+                patterns.append(line)
+        return patterns
+
+    @staticmethod
+    def _split_gitignore_patterns(gitignore_patterns: list) -> tuple:
+        """
+        Split the .gitignore patterns into folder patterns and file patterns.
+
+        Args:
+            gitignore_patterns (list): A list of patterns from the .gitignore file.
+
+        Returns:
+            tuple: Two lists, one for folder patterns and one for file patterns.
+        """
+        folder_patterns = []
+        file_patterns = []
+        for pattern in gitignore_patterns:
+            if pattern.endswith('/'):
+                folder_patterns.append(pattern.rstrip('/'))
+            else:
+                file_patterns.append(pattern)
+        return folder_patterns, file_patterns
+
+    @staticmethod
+    def _is_ignored(path: str, patterns: list, is_dir: bool=False) -> bool:
+        """
+        Check if the given path matches any of the patterns.
+
+        Args:
+            path (str): The path to check.
+            patterns (list): A list of patterns to check against.
+            is_dir (bool): True if the path is a directory, False otherwise.
+
+        Returns:
+            bool: True if the path matches any pattern, False otherwise.
+        """
+        for pattern in patterns:
+            if fnmatch.fnmatch(path, pattern):
+                return True
+            if is_dir and pattern.endswith('/') and fnmatch.fnmatch(path, pattern[:-1]):
+                return True
+        return False
+
+    def check_files_and_folders(self) -> list:
+        """
+        Check all files and folders in the given directory against the split gitignore patterns.
+        Return a list of files that are not ignored and have the '.py' extension.
+        The returned file paths are relative to the self.directory.
+
+        Returns:
+            list: A list of paths to files that are not ignored and have the '.py' extension.
+        """
+        not_ignored_files = []
+        for root, dirs, files in os.walk(self.directory):
+            dirs[:] = [d for d in dirs if not self._is_ignored(d, self.folder_patterns, is_dir=True)]
+
+            for file in files:
+                file_path = os.path.join(root, file)
+                relative_path = os.path.relpath(file_path, self.directory)
+                if not self._is_ignored(file, self.file_patterns) and file_path.endswith('.py'):
+                    not_ignored_files.append(relative_path)
+
+        return not_ignored_files
+
+
+# Example usage:
+# gitignore_checker = GitignoreChecker('path_to_directory', 'path_to_gitignore_file')
+# not_ignored_files = gitignore_checker.check_files_and_folders()
+# print(not_ignored_files)


### PR DESCRIPTION
- I've implemented a solution where we use the contents of `.gitignore` in our codebase to establish a list of patterns to ignore. This allows us to specifically target and process files within the desired scope, avoiding those that are specified in `.gitignore`. This approach should help in efficiently narrowing down the range of files `generate_overall_structure` processes, aligning it more closely with our project's relevant files.

- This change treats `.gitignore` as specifying two types of ignore patterns: one ending with `/` as the folder mode, and the other as the file mode. In the `check_files_and_folders` method, it first matches the folder mode to speed up processing.

- fix #14 .

## Results

**only those relevant files.**

![image](https://github.com/LOGIC-10/AI_doc/assets/138990495/7de6ad0e-9012-4d2f-91f3-cb328404c1ef)

**My codebase structure.**
![image](https://github.com/LOGIC-10/AI_doc/assets/138990495/5eb26e06-c9c2-4a28-905f-46217875c600)

**AI doc file.**
![image](https://github.com/LOGIC-10/AI_doc/assets/138990495/1a1d6a40-0995-4a0e-aa79-14ec92c658a8)
